### PR TITLE
Fix - Analytics channel 'shares'

### DIFF
--- a/lib/yt/associations/has_reports.rb
+++ b/lib/yt/associations/has_reports.rb
@@ -257,8 +257,9 @@ module Yt
       end
 
       def define_metric_method(metric)
+
         define_method metric do |options = {}|
-          from = options[:since] || options[:from] || (options[:by].in?([:day, :week, :month]) ? 5.days.ago : '2005-02-01')
+          from = options[:since] || options[:from] || (options[:by].in?([:day, :week, :month]) ? 5.days.ago : '2005-02-01') rescue '2005-02-01'
           to = options[:until] || options[:to] || Date.today
           location = options[:in]
           country = location.is_a?(Hash) ? location[:country] : location

--- a/lib/yt/associations/has_reports.rb
+++ b/lib/yt/associations/has_reports.rb
@@ -235,7 +235,7 @@ module Yt
       def define_reports_method(metric, type)
         (@metrics ||= {})[metric] = type
         define_method :reports do |options = {}|
-          from = options[:since] || options[:from] || (options[:by].in?([:day, :week, :month]) ? 5.days.ago : '2005-02-01')
+          from = options[:since] || options[:from] || ( [:day, :week, :month].include?(options[:by]) ? 5.days.ago : '2005-02-01' )
           to = options[:until] || options[:to] || Date.today
           location = options[:in]
           country = location.is_a?(Hash) ? location[:country] : location
@@ -250,16 +250,15 @@ module Yt
 
           only = options.fetch :only, []
           reports = Collections::Reports.of(self).tap do |reports|
-            reports.metrics =  self.class.instance_variable_get(:@metrics).select{|k, v| k.in? only}
+            reports.metrics =  self.class.instance_variable_get(:@metrics).select{|k, v| only.include?(k)}
           end
           reports.within date_range, country, state, dimension, videos
         end unless defined?(reports)
       end
 
       def define_metric_method(metric)
-
         define_method metric do |options = {}|
-          from = options[:since] || options[:from] || (options[:by].in?([:day, :week, :month]) ? 5.days.ago : '2005-02-01') rescue '2005-02-01'
+          from = options[:since] || options[:from] || ( [:day, :week, :month].include?(options[:by]) ? 5.days.ago : '2005-02-01' )
           to = options[:until] || options[:to] || Date.today
           location = options[:in]
           country = location.is_a?(Hash) ? location[:country] : location

--- a/lib/yt/associations/has_reports.rb
+++ b/lib/yt/associations/has_reports.rb
@@ -235,7 +235,7 @@ module Yt
       def define_reports_method(metric, type)
         (@metrics ||= {})[metric] = type
         define_method :reports do |options = {}|
-          from = options[:since] || options[:from] || ( [:day, :week, :month].include?(options[:by]) ? 5.days.ago : '2005-02-01' )
+          from = options[:since] || options[:from] || ([:day, :week, :month].include?(options[:by]) ? 5.days.ago : '2005-02-01')
           to = options[:until] || options[:to] || Date.today
           location = options[:in]
           country = location.is_a?(Hash) ? location[:country] : location
@@ -258,7 +258,7 @@ module Yt
 
       def define_metric_method(metric)
         define_method metric do |options = {}|
-          from = options[:since] || options[:from] || ( [:day, :week, :month].include?(options[:by]) ? 5.days.ago : '2005-02-01' )
+          from = options[:since] || options[:from] || ([:day, :week, :month].include?(options[:by]) ? 5.days.ago : '2005-02-01')
           to = options[:until] || options[:to] || Date.today
           location = options[:in]
           country = location.is_a?(Hash) ? location[:country] : location

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -85,7 +85,7 @@ module Yt
             end
           elsif dimension == :day
             hash = hash.transform_values{|h| h.sort_by{|day, v| day}.to_h}
-          elsif dimension.in? [:traffic_source, :country, :state, :playback_location, :device_type]
+          elsif [:traffic_source, :country, :state, :playback_location, :device_type].include?(dimension)
             hash = hash.transform_values{|h| h.sort_by{|range, v| -v}.to_h}
           end
           (@metrics.one? || @metrics.keys == [:earnings, :estimated_minutes_watched]) ? hash[@metrics.keys.first] : hash
@@ -128,9 +128,9 @@ module Yt
           params['end-date'] = @days_range.end
           params['metrics'] = @metrics.keys.join(',').to_s.camelize(:lower)
           params['dimensions'] = DIMENSIONS[@dimension][:name] unless @dimension == :range
-          params['max-results'] = 50 if @dimension.in? [:playlist, :video]
-          params['max-results'] = 25 if @dimension.in? [:embedded_player_location, :related_video, :search_term, :referrer]
-          if @dimension.in? [:video, :playlist, :embedded_player_location, :related_video, :search_term, :referrer]
+          params['max-results'] = 50 if [:playlist, :video].include?(@dimension)
+          params['max-results'] = 25 if [:embedded_player_location, :related_video, :search_term, :referrer].include?(@dimension)
+          if [:video, :playlist, :embedded_player_location, :related_video, :search_term, :referrer].include?(@dimension)
             if @metrics.keys == [:earnings, :estimated_minutes_watched]
               params['sort'] = '-earnings'
             else

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -63,27 +63,20 @@ module Yt
         @country = country
         @state = state
         @videos = videos
-
         if dimension == :gender_age_group # array of array
           Hash.new{|h,k| h[k] = Hash.new 0.0}.tap do |hash|
             each{|gender, age_group, value| hash[gender][age_group[3..-1]] = value}
           end
         else
-
           hash = flat_map do |hashes|
             hashes.map do |metric, values|
-              # [ metric, values.transform_values { |v| type_cast(v, @metrics[metric]) } ]
               [ metric, values.inject({}) { |h, (k, v)| h[k] = type_cast(v, @metrics[metric]); h } ]
             end.to_h
           end
-
-          # hash = hash.inject(@metrics.transform_values { |v| {} }) do |result, hash|
           hash = hash.inject(@metrics.inject({}) { |h, (k, v)| h[k] = {}; h }) do |result, hash|
             result.deep_merge hash
           end
-
           if dimension == :month
-            # hash = hash.transform_values{|h| h.sort_by{|range, v| range.first}.to_h}
             hash = hash.inject({}) { |h, (k, v)| v.sort_by { |range, v| range.first }.to_h; h }
           elsif dimension == :week
             hash = hash.transform_values do |h|
@@ -95,7 +88,6 @@ module Yt
           elsif [:traffic_source, :country, :state, :playback_location, :device_type].include?(dimension)
             hash = hash.transform_values{|h| h.sort_by{|range, v| -v}.to_h}
           end
-
           (@metrics.one? || @metrics.keys == [:earnings, :estimated_minutes_watched]) ? hash[@metrics.keys.first] : hash
         end
       # NOTE: Once in a while, YouTube responds with 400 Error and the message

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -84,7 +84,7 @@ module Yt
 
           if dimension == :month
             # hash = hash.transform_values{|h| h.sort_by{|range, v| range.first}.to_h}
-            hash = hash.inject({}) { |h, (k, v)| h.sort_by { |range, v| range.first }.to_h; h }
+            hash = hash.inject({}) { |h, (k, v)| v.sort_by { |range, v| range.first }.to_h; h }
           elsif dimension == :week
             hash = hash.transform_values do |h|
               h.select{|range, v| range.last.wday == days_range.last.wday}.

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -70,14 +70,14 @@ module Yt
         else
           hash = flat_map do |hashes|
             hashes.map do |metric, values|
-              [ metric, values.inject({}) { |h, (k, v)| h[k] = type_cast(v, @metrics[metric]); h } ]
+              [metric, values.inject({}) {|h, (k,v)| h[k] = type_cast(v, @metrics[metric]); h }]
             end.to_h
           end
-          hash = hash.inject(@metrics.inject({}) { |h, (k, v)| h[k] = {}; h }) do |result, hash|
+          hash = hash.inject(@metrics.inject({}) {|h, (k,v)| h[k] = {}; h }) do |result, hash|
             result.deep_merge hash
           end
           if dimension == :month
-            hash = hash.inject({}) { |h, (k, v)| v.sort_by { |range, v| range.first }.to_h; h }
+            hash = hash.inject({}) {|h, (k,v)| v.sort_by {|range, v| range.first}.to_h; h }
           elsif dimension == :week
             hash = hash.transform_values do |h|
               h.select{|range, v| range.last.wday == days_range.last.wday}.

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -63,7 +63,6 @@ module Yt
         @country = country
         @state = state
         @videos = videos
-        binding.pry
 
         if dimension == :gender_age_group # array of array
           Hash.new{|h,k| h[k] = Hash.new 0.0}.tap do |hash|

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -70,14 +70,14 @@ module Yt
         else
           hash = flat_map do |hashes|
             hashes.map do |metric, values|
-              [metric, values.inject({}){|h,(k,v)| h[k] = type_cast(v, @metrics[metric]); h }]
+              [metric, values.inject({}){|h,(k,v)| h[k] = type_cast(v, @metrics[metric]); h}]
             end.to_h
           end
-          hash = hash.inject(@metrics.inject({}){|h,(k,v)| h[k] = {}; h }) do |result, hash|
+          hash = hash.inject(@metrics.inject({}){|h,(k,v)| h[k] = {}; h}) do |result, hash|
             result.deep_merge hash
           end
           if dimension == :month
-            hash = hash.inject({}){|h,(k,v)| v.sort_by{|range, v| range.first}.to_h; h }
+            hash = hash.inject({}){|h,(k,v)| v.sort_by{|range, v| range.first}.to_h; h}
           elsif dimension == :week
             hash = hash.transform_values do |h|
               h.select{|range, v| range.last.wday == days_range.last.wday}.

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -70,14 +70,14 @@ module Yt
         else
           hash = flat_map do |hashes|
             hashes.map do |metric, values|
-              [metric, values.inject({}) {|h, (k,v)| h[k] = type_cast(v, @metrics[metric]); h }]
+              [metric, values.inject({}){|h,(k,v)| h[k] = type_cast(v, @metrics[metric]); h }]
             end.to_h
           end
-          hash = hash.inject(@metrics.inject({}) {|h, (k,v)| h[k] = {}; h }) do |result, hash|
+          hash = hash.inject(@metrics.inject({}){|h,(k,v)| h[k] = {}; h }) do |result, hash|
             result.deep_merge hash
           end
           if dimension == :month
-            hash = hash.inject({}) {|h, (k,v)| v.sort_by {|range, v| range.first}.to_h; h }
+            hash = hash.inject({}){|h,(k,v)| v.sort_by{|range, v| range.first}.to_h; h }
           elsif dimension == :week
             hash = hash.transform_values do |h|
               h.select{|range, v| range.last.wday == days_range.last.wday}.

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -79,14 +79,15 @@ module Yt
           if dimension == :month
             hash = hash.inject({}){|h,(k,v)| v.sort_by{|range, v| range.first}.to_h; h}
           elsif dimension == :week
-            hash = hash.transform_values do |h|
-              h.select{|range, v| range.last.wday == days_range.last.wday}.
-              sort_by{|range, v| range.first}.to_h
+            hash = hash.inject({}) do |h,(k,v)|
+              v.select{|range, v| range.last.wday == days_range.last.wday}.
+              sort_by{|range, v| range.first }.to_h
+              h
             end
           elsif dimension == :day
-            hash = hash.transform_values{|h| h.sort_by{|day, v| day}.to_h}
+            hash = hash.inject({}){|h,(k,v)| v.sort_by{|day, v| day}.to_h; h}
           elsif [:traffic_source, :country, :state, :playback_location, :device_type].include?(dimension)
-            hash = hash.transform_values{|h| h.sort_by{|range, v| -v}.to_h}
+            hash = hash.inject({}){|h,(k,v)| v.sort_by{|range, v| -v}.to_h; h}
           end
           (@metrics.one? || @metrics.keys == [:earnings, :estimated_minutes_watched]) ? hash[@metrics.keys.first] : hash
         end


### PR DESCRIPTION
Essentially this removes ActiveSupport `String#in?` with `Array#include?` as well as `Hash#transform_values` with `Hash#inject`

This enables the use of `channel.shares` and `channel.reports`